### PR TITLE
Ci tests

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,10 +1,14 @@
 name: Docker Image CI
 on:
   workflow_dispatch:
+    inputs:
+      test_list:
+        description: Only run tests that match the regular expression
+        default: ""
+        required: false
 
-  pull_request:
-    branch: ['main']
-    types: ['closed']
+  push:
+    branches: ['main']
 
 jobs:
   build:


### PR DESCRIPTION
### Description
Think we need to have inputs for the workflow_dispatch to properly call from kraken to run a new docker build and push action

See how in below job it just calls to see most recent action in kraken-hub not call the dispatch 
https://github.com/cloud-bulldozer/kraken/runs/4153586182?check_suite_focus=true 
