### PR TITLE
Set pod label selector to null by default

### DIFF
--- a/docs/pod-scenarios.md
+++ b/docs/pod-scenarios.md
@@ -31,10 +31,10 @@ Parameter               | Description                                           
 ----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
 RUNS                    | Number of iterations to run the scenario                              | 1                                    |
 SECONDS_BETWEEN_RUNS    | Time in seconds to wait before each of the iteration                  | 30                                   |
-NAMESPACE               | Targeted namespace in the cluster                                     | openshift-etcd                       |
-POD_LABEL               | Label of the pod(s) to target                                         | app=etcd                             | 
+NAMESPACE               | Targeted namespace in the cluster                                     | openshift-.*                         |
+POD_LABEL               | Label of the pod(s) to target                                         | ""                                   | 
 DISRUPTION_COUNT        | Number of pods to disrupt                                             | 1                                    |
-EXPECTED_POD_COUNT      | Total pod count matching the label to verify post disruption          | 3                                    |
+EXPECTED_POD_COUNT      | Total pod count matching the label to verify post disruption          | ""                                   |
 TIMEOUT                 | Time in seconds to wait for the target pods to match EXPECTED_POD_COUNT | 180                                |
 CERBERUS_ENABLED        | Set this to true if cerberus is running and monitoring the cluster    | False                                |
 CERBERUS_URL            | URL to poll for the go/no-go signal                                   | http://0.0.0.0:8080                  |

--- a/pod-scenarios/env.sh
+++ b/pod-scenarios/env.sh
@@ -3,10 +3,10 @@
 # Vars and respective defaults
 export RUNS=${RUNS:=1}
 export SECONDS_BETWEEN_RUNS=${SECONDS_BETWEEN_RUNS:=30}
-export NAMESPACE=${NAMESPACE:="openshift-etcd"}
-export POD_LABEL=${POD_LABEL:="app=etcd"}
+export NAMESPACE=${NAMESPACE:="openshift-.*"}
+export POD_LABEL=${POD_LABEL:=""}
 export DISRUPTION_COUNT=${DISRUPTION_COUNT:=1}
-export EXPECTED_POD_COUNT=${EXPECTED_POD_COUNT:=3}
+export EXPECTED_POD_COUNT=${EXPECTED_POD_COUNT:=""}
 export TIMEOUT=${TIMEOUT:=180}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=pod_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=- scenarios/pod_scenario.yaml}


### PR DESCRIPTION
### Description
This is needed to avoid using a specific label by default to find the
pods to target.

