### PR TITLE
Add ability to delete pods in a namespace without pod-label

### DIFF
--- a/docs/pod-scenarios.md
+++ b/docs/pod-scenarios.md
@@ -31,10 +31,10 @@ Parameter               | Description                                           
 ----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
 RUNS                    | Number of iterations to run the scenario                              | 1                                    |
 SECONDS_BETWEEN_RUNS    | Time in seconds to wait before each of the iteration                  | 30                                   |
-NAMESPACE               | Targeted namespace in the cluster                                     | openshift-etcd                       |
-POD_LABEL               | Label of the pod(s) to target                                         | app=etcd                             | 
+NAMESPACE               | Targeted namespace in the cluster                                     | openshift-.*                         |
+POD_LABEL               | Label of the pod(s) to target                                         | ""                                   | 
 DISRUPTION_COUNT        | Number of pods to disrupt                                             | 1                                    |
-EXPECTED_POD_COUNT      | Total pod count matching the label to verify post disruption          | 3                                    |
+EXPECTED_POD_COUNT      | Total pod count matching the label to verify post disruption ( REQUIRED when POD_LABEL is set )| ""          |
 TIMEOUT                 | Time in seconds to wait for the target pods to match EXPECTED_POD_COUNT | 180                                |
 CERBERUS_ENABLED        | Set this to true if cerberus is running and monitoring the cluster    | False                                |
 CERBERUS_URL            | URL to poll for the go/no-go signal                                   | http://0.0.0.0:8080                  |

--- a/pod-scenarios/Dockerfile
+++ b/pod-scenarios/Dockerfile
@@ -17,5 +17,6 @@ COPY env.sh /root/main_env.sh
 COPY pod-scenarios/run.sh /root/run.sh
 COPY common_run.sh /root/common_run.sh
 COPY pod-scenarios/pod_scenario.yaml.template /root/kraken/scenarios/pod_scenario.yaml.template
+COPY pod-scenarios/pod_scenario_namespace.yaml.template /root/kraken/scenarios/pod_scenario_namespace.yaml.template
 
 ENTRYPOINT /root/run.sh

--- a/pod-scenarios/env.sh
+++ b/pod-scenarios/env.sh
@@ -3,10 +3,10 @@
 # Vars and respective defaults
 export RUNS=${RUNS:=1}
 export SECONDS_BETWEEN_RUNS=${SECONDS_BETWEEN_RUNS:=30}
-export NAMESPACE=${NAMESPACE:="openshift-etcd"}
-export POD_LABEL=${POD_LABEL:="app=etcd"}
+export NAMESPACE=${NAMESPACE:="openshift-.*"}
+export POD_LABEL=${POD_LABEL:=""}
 export DISRUPTION_COUNT=${DISRUPTION_COUNT:=1}
-export EXPECTED_POD_COUNT=${EXPECTED_POD_COUNT:=3}
+export EXPECTED_POD_COUNT=${EXPECTED_POD_COUNT:=""}
 export TIMEOUT=${TIMEOUT:=180}
 export SCENARIO_TYPE=${SCENARIO_TYPE:=pod_scenarios}
 export SCENARIO_FILE=${SCENARIO_FILE:=- scenarios/pod_scenario.yaml}

--- a/pod-scenarios/pod_scenario_namespace.yaml.template
+++ b/pod-scenarios/pod_scenario_namespace.yaml.template
@@ -1,0 +1,20 @@
+config:
+  runStrategy:
+    runs: $RUNS
+    maxSecondsBetweenRuns: $SECONDS_BETWEEN_RUNS
+    minSecondsBetweenRuns: 1
+scenarios:
+  - name: kill pods in the specified namespace
+    steps:
+    - podAction:
+        matches:
+          - namespace: "$NAMESPACE"
+        filters:
+          - property:
+             name: "state"
+             value: "Running"
+          - randomSample:
+              size: $DISRUPTION_COUNT
+        actions:
+          - kill:
+              probability: .7

--- a/pod-scenarios/run.sh
+++ b/pod-scenarios/run.sh
@@ -13,7 +13,11 @@ checks
 config_setup
 
 # Substitute config with environment vars defined
-envsubst < /root/kraken/scenarios/pod_scenario.yaml.template > /root/kraken/scenarios/pod_scenario.yaml
+if [[ -z "$POD_LABEL" ]]; then
+  envsubst < /root/kraken/scenarios/pod_scenario_namespace.yaml.template > /root/kraken/scenarios/pod_scenario.yaml
+else  
+  envsubst < /root/kraken/scenarios/pod_scenario.yaml.template > /root/kraken/scenarios/pod_scenario.yaml
+fi
 envsubst < /root/kraken/config/config.yaml.template > /root/kraken/config/pod_scenario_config.yaml
 
 # Run Kraken


### PR DESCRIPTION
### Description
This commit also:
- Sets the default pod-selector and expected pod count to null
  to avoid using a specific label by default to find the pods to target and
  validate the recovery.
- Changes the default namespace from openshift-etcd to openshift-.*.
  This picks a random namespace to kill the pods.
