### PR TITLE
Adding missing parameters to docs and inspect components, sleep param

### DIFF
--- a/cerberus/cerberus.yaml.template
+++ b/cerberus/cerberus.yaml.template
@@ -1,6 +1,6 @@
 cerberus:
     distribution: openshift                              # Distribution can be kubernetes or openshift
-    kubeconfig_path: /root/.kube/config                       # Path to kubeconfig
+    kubeconfig_path: $CERBERUS_KUBECONFIG                       # Path to kubeconfig
     port: $CERBERUS_PORT                                           # http server port where cerberus status is published
     watch_nodes: $CERBERUS_WATCH_NODES                                    # Set to True for the cerberus to monitor the cluster nodes
     watch_cluster_operators: $CERBERUS_WATCH_OPERATORS                        # Set to True for cerberus to monitor cluster operators
@@ -10,7 +10,7 @@ cerberus:
         label: node-role.kubernetes.io/master
     watch_namespaces: $CERBERUS_WATCH_NAMESPACES                                   # List of namespaces to be monitored
     cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
-    inspect_components: False                            # Enable it only when OpenShift client is supported to run
+    inspect_components: $INSPECT_COMPONENTS                            # Enable it only when OpenShift client is supported to run
                                                          # When enabled, cerberus collects logs, events and metrics of failed components
 
     prometheus_url:                                      # The prometheus url/route is automatically obtained in case of OpenShift, please set it when the distribution is Kubernetes.
@@ -35,7 +35,7 @@ cerberus:
 tunings:
     timeout: $CERBERUS_TIMEOUT                                          # Number of seconds before requests fail
     iterations: $CERBERUS_ITERATIONS                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
-    sleep_time: 5                                       # Sleep duration between each iteration
+    sleep_time: $CERBERUS_SLEEP                                       # Sleep duration between each iteration
     kube_api_request_chunk_size: 250                     # Large requests will be broken into the specified chunk size to reduce the load on API server and improve responsiveness.
     daemon_mode: $CERBERUS_DAEMON_MODE                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
     cores_usage_percentage: $CERBERUS_CORES                          # Set the fraction of cores to be used for multiprocessing

--- a/cerberus/env.sh
+++ b/cerberus/env.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 # Vars and respective defaults
+export CERBERUS_KUBECONFIG=/root/.kube/config
 export CERBERUS_PORT=${CERBERUS_PORT:=8080}
 export CERBERUS_WATCH_NODES=${CERBERUS_WATCH_NODES:=True}
 export CERBERUS_WATCH_OPERATORS=${CERBERUS_WATCH_OPERATORS:=True}
 export CERBERUS_WATCH_NAMESPACES=${CERBERUS_WATCH_NAMESPACES:=[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller-manager, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn]}
 export CERBERUS_TIMEOUT=${CERBERUS_TIMEOUT:=3}
+export CERBERUS_SLEEP=${CERBERUS_SLEEP:=3}
 export CERBERUS_CORES=${CERBERUS_CORES:=1}
 export CERBERUS_ITERATIONS=${CERBERUS_ITERATIONS:=5}
 export CERBERUS_DAEMON_MODE=${CERBERUS_DAEMON_MODE:=True}
+export INSPECT_COMPONENTS=${INSPECT_COMPONENTS:=False}

--- a/docs/cerberus.md
+++ b/docs/cerberus.md
@@ -19,11 +19,14 @@ $ docker run -e VARIABLE=value --net=host -v <path-to-kube-config>:/root/.kube/c
 The following environment variables can be set on the host running the container to tweak the configuration:
 
 Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-KUBECONFIG              | Path to the kubeconfig to access the cluster API                      | /root/.kube/config                   |
+----------------------- | -----------------------------------------------------------------     | ------------------------------------ |   
 CERBERUS_PORT           | HTTP server port where cerberus status is published                   | 8080                                 |
 CERBERUS_WATCH_NODES    | Set to True for the cerberus to monitor the cluster nodes             | True                                 |
 CERBERUS_WATCH_OPERATORS | Set to True for cerberus to monitor cluster operators                | True                                 |
 CERBERUS_WATCH_NAMESPACES |  List of namespaces to be monitored                                 | [openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller-manager, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn] |
 CERBERUS_TIMEOUT        | Number of seconds before requests fail                                | 3                                    |
+CERBERUS_SLEEP          | Number of seconds between iterations of Cerberus                      | 3                                    |
+CERBERUS_ITERATIONS     | Number of iterations to run                                           | 5                                    |
+CERBERUS_DAEMON_MODE    | Infinitely run cerberus on cluster, will ignore iterations if this is set to true               | 3                                    |
 CERBERUS_CORES          | Set the fraction of cores to be used for multiprocessing              | 1                                    |
+INSPECT_COMPONENTS      | Enable it only when OpenShift client is supported to run; collects logs, events and metrics of failed components | False  | 


### PR DESCRIPTION
### Description
Missing documentation for a couple of options in cerberus 

Also added option for inspect components


